### PR TITLE
Mute sub-Task-Kensho updates

### DIFF
--- a/gumbypan.pl
+++ b/gumbypan.pl
@@ -217,6 +217,7 @@ sub _uploads {
 	    my $regexp = $channels{$channel};
       next if $channel eq '#perl' and $author eq 'INA' and $module =~ /^Char\-/;
       next if $channel eq '#perl' and $author eq 'PETAMEM' and $module =~ /^Lingua\-/;
+      next if $channel eq '#perl' and $module =~ /^Task-Kensho-\D/;
 	    eval {
 	      $irc->yield( 'ctcp', $channel, "ACTION CPAN Upload: $module by $author http://metacpan.org/release/$author/$module" ) if $module =~ /$regexp/;
 	    }


### PR DESCRIPTION
A fix to mute sub-distros of Task-Kensho group of distros, since Task-Kensho would likely be uploaded at the same time any way.

Below is a screenshot of how the Task-Kensho updates currently show up in channel:

![9i6ifcl](https://f.cloud.github.com/assets/5747918/1970721/2b8682a6-8312-11e3-8b41-b1502fca1861.png)
